### PR TITLE
massive add: layout changes, not-found page, global types

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,11 +9,7 @@ export default function Home() {
           <h3>Bienvenido a DataUnion</h3>
           <p> Combina, organiza y edita tus datos de Excel directamente desde tu navegador </p>
         </div>
-        {/* <div className={styles.card}>
-          <h3>Estadísticas Rápidas</h3>
-          <p>Archivos subidos: <strong>0</strong></p>
-          <p>Espacio usado: <strong>0 MB</strong></p>
-        </div> */}
+
       </div>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="es">
-      <body className={inter.className}>
+    <html suppressHydrationWarning lang="es">
+      <body suppressHydrationWarning className={inter.className}>
         <Layout>{children}</Layout>
       </body>
     </html>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+export default function NotFound() {
+  // Redirección automática al dashboard
+  redirect('/dashboard');
+}

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -4,7 +4,6 @@ import styles from './page.module.css';
 export default function UploadPage() {
   return (
     <div className={styles.container}>
-      {/* <h1 className={styles.title}></h1> */}
       <FileUpload />
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,34 +30,8 @@ export default function Sidebar({ isOpen }: SidebarProps) {
       ),
       label: 'Subir Archivos'
     },
-    {
-      href: '/files',
-      icon: (
-        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-      ),
-      label: 'Mis Archivos'
-    },
-    // {
-    //   href: '/analytics',
-    //   icon: (
-    //     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    //       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-    //     </svg>
-    //   ),
-    //   label: 'Analíticas'
-    // },
-    {
-      href: '/settings',
-      icon: (
-        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-        </svg>
-      ),
-      label: 'Configuración'
-    }
+
+    
   ];
 
   if (!isOpen) {

--- a/src/components/TopNav.module.css
+++ b/src/components/TopNav.module.css
@@ -126,15 +126,14 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  cursor: pointer;
   padding: 0.25rem;
   border-radius: 6px;
   transition: background-color 0.2s ease;
 }
 
-.userMenu:hover {
+/* .userMenu:hover {
   background-color: #f1f5f9;
-}
+} */
 
 .userAvatar {
   width: 32px;

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -20,37 +20,10 @@ export default function TopNav({ onToggleSidebar, isSidebarOpen }: TopNavProps) 
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
           </svg>
         </button>
-        {/* <div className={styles.breadcrumb}>
-          <span>Dashboard</span>
-        </div> */}
       </div>
 
       <div className={styles.navRight}>
-        {/* <div className={styles.searchBar}>
-          <svg className={styles.searchIcon} fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input 
-            type="text" 
-            placeholder="Buscar..." 
-            className={styles.searchInput}
-          />
-        </div> */}
-
         <div className={styles.navActions}>
-          {/* <button className={styles.navButton}>
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-            </svg>
-            <span className={styles.notificationBadge}>3</span>
-          </button> */}
-
-          <button className={styles.navButton}>
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </button>
-
           <div className={styles.userMenu}>
             <div className={styles.userAvatar}>
               <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,23 @@
+// Declaraciones de tipos para módulos CSS
+declare module '*.css' {
+  const content: Record<string, string>;
+  export default content;
+}
+
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+declare module '*.scss' {
+  const content: Record<string, string>;
+  export default content;
+}
+
+declare module '*.module.scss' {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+// Para importaciones de CSS globales (side-effect imports)
+declare module '../styles/globals.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,9 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "typeRoots": ["./node_modules/@types", "./src/types"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This pull request primarily cleans up the UI by removing commented-out code and unused navigation elements, improves hydration handling for Next.js, and adds a redirect for not-found pages. These changes help streamline the codebase and enhance user experience by reducing clutter and ensuring better navigation flow.

**UI Cleanup and Navigation Simplification:**
- Removed commented-out sections for quick statistics and breadcrumbs from the dashboard and top navigation, reducing visual and code clutter (`src/app/dashboard/page.tsx`, `src/components/TopNav.tsx`) [[1]](diffhunk://#diff-2c144079a4338bcfeecc2c0f8557d1a11faa7f2ba8ad92283138f05b8806888fL12-R12) [[2]](diffhunk://#diff-12b928c0113105920a8a982b0c71bd1e4fb2d0872d81add9a2a2a3a77ee6cbb9L23-L53).
- Removed the "Mis Archivos" and "Analíticas" navigation items from the sidebar, leaving only essential navigation links (`src/components/Sidebar.tsx`).
- Removed commented-out title from the upload page for a cleaner interface (`src/app/upload/page.tsx`).

**Hydration and Styling Improvements:**
- Added `suppressHydrationWarning` to the `<html>` and `<body>` elements in the root layout to address hydration mismatches in Next.js (`src/app/layout.tsx`).
- Disabled the hover background color effect for the user menu in top navigation by commenting out the relevant CSS (`src/components/TopNav.module.css`).

**Navigation and Error Handling:**
- Implemented automatic redirection from the not-found page to the dashboard, improving user flow when encountering invalid routes (`src/app/not-found.tsx`).