### PR TITLE
feat: Building errors fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build Next.js
         run: npm run build
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}

--- a/src/components/ExcelEditor.tsx
+++ b/src/components/ExcelEditor.tsx
@@ -9,10 +9,12 @@ import { saveAs } from "file-saver";
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
+// TODO: Properly type this dynamic import instead of using 'as any'
+// Cleaner fix: import { AgGridReact as AgGridReactType } from 'ag-grid-react' and use ComponentType<AgGridReactProps>
 const AgGridReact = dynamic(
   () => import("ag-grid-react").then((mod) => mod.AgGridReact),
   { ssr: false }
-);
+) as any;
 
 export default function ExcelEditorAGGrid() {
   const [rowData, setRowData] = useState<any[]>([]);
@@ -42,7 +44,8 @@ export default function ExcelEditorAGGrid() {
 
         if (jsonData.length === 0) return;
 
-        const cols = jsonData[0].map((val, index) => ({ //sgy este error va a matar el deploy
+        // TODO: validate proper type for Excel cell values (currently any)
+        const cols = jsonData[0].map((val: any, index: number) => ({
           headerName: val || `Col ${index + 1}`,
           field: `col_${index}`,
           editable: true,

--- a/src/components/NormaMinsal.tsx
+++ b/src/components/NormaMinsal.tsx
@@ -11,10 +11,12 @@ import * as XLSX from "xlsx";
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 // Import dinámico de AG Grid React
+// TODO: Properly type this dynamic import instead of using 'as any'
+// Cleaner fix: import { AgGridReact as AgGridReactType } from 'ag-grid-react' and use ComponentType<AgGridReactProps>
 const AgGridReact = dynamic(
   () => import("ag-grid-react").then((mod) => mod.AgGridReact),
   { ssr: false }
-);
+) as any;
 
 export default function NormaMinsalPage() {
   const [rowData, setRowData] = useState<any[]>([]);
@@ -44,7 +46,8 @@ export default function NormaMinsalPage() {
 
         if (jsonData.length === 0) return;
 
-        const cols = jsonData[0].map((val, index) => ({
+        // TODO: validate proper type for Excel cell values (currently any)
+        const cols = jsonData[0].map((val: any, index: number) => ({
         headerName: val || `Col ${index + 1}`, // usa el valor de la celda, si está vacío, usa Col #
         field: `col_${index}`,
         editable: true,
@@ -111,6 +114,8 @@ export default function NormaMinsalPage() {
               }}
             />
           </div>
+        </>
+      )}
 
       {rowData.length === 0 && <p>Selecciona un archivo para cargar la tabla...</p>}
     </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,7 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/types/**/*.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- TypeScript errors in `NormaMinsal.tsx` and `ExcelEditor.tsx`
- `tsconfig.json` error regarding `typeRoots` attribute. It was incorrect, as our `types/types/` directory:
- -> Has no index file to be considered as a module
- -> Only served for declaring modules for third party libraries.
- -> The `include` array already picks up the `.d.ts` files.