### PR TITLE
feat:implement rejection workflow for GRD episodes

### DIFF
--- a/docs/LIMPIEZA-BD.md
+++ b/docs/LIMPIEZA-BD.md
@@ -1,0 +1,217 @@
+# Plan de Limpieza de Base de Datos - Documentos en Flujo
+
+**Fecha:** 2 de Diciembre, 2025  
+**Objetivo:** Limpiar la BD de documentos en flujo para resetear el ambiente de testing
+
+---
+
+## 📊 Estado Actual de la Base de Datos
+
+### Resumen de Documentos en Flujo
+
+| Estado | Total Filas | Total Archivos | Descripción |
+|--------|------------|-----------------|------------|
+| `borrador_encoder` | 0 | 0 | Archivos en edición por Encoder |
+| `pendiente_finance` | 544 | 1 | Archivos esperando revisión de Finance ⚠️ |
+| `borrador_finance` | 0 | 0 | Archivos en edición por Finance |
+| `pendiente_admin` | 0 | 0 | Archivos esperando aprobación de Admin |
+| `rechazado` | 0 | 0 | Archivos rechazados |
+| **TOTAL** | **544** | **1** | - |
+
+### Archivo en Flujo
+
+- **ID GRD Oficial:** 68
+- **Total de Filas (Episodios):** 544
+- **Estado Actual:** `pendiente_finance`
+- **Acción Requerida:** Limpiar este archivo para liberar el flujo
+
+---
+
+## 🧹 Opciones de Limpieza
+
+### Opción 1: Limpiar Completamente (RECOMENDADO para Testing Fresh)
+
+**Impacto:** Borra el archivo GRD completo  
+**Tiempo:** < 1 segundo  
+**Reversible:** No (pero se puede reimportar desde SIGESA)
+
+```sql
+-- Opción 1: Borrar todo el archivo GRD ID 68
+DELETE FROM grd_fila WHERE id_grd_oficial = 68;
+```
+
+**Resultado:** Sistema completamente limpio para nuevo testing
+
+---
+
+### Opción 2: Cambiar Estado a "Exportado" (PRESERVA DATOS)
+
+**Impacto:** Cierra el flujo pero conserva los datos  
+**Tiempo:** < 1 segundo  
+**Reversible:** Sí (cambiar estado de vuelta)
+
+```sql
+-- Opción 2: Cambiar estado a exportado (finaliza flujo normalmente)
+UPDATE grd_fila SET estado = 'exportado' WHERE id_grd_oficial = 68;
+```
+
+**Resultado:** Archivo cierra el flujo sin errores, datos preservados
+
+---
+
+### Opción 3: Cambiar Estado a "Borrador Encoder" (REINICIAR FLUJO)
+
+**Impacto:** Devuelve el archivo a Encoder para re-edición  
+**Tiempo:** < 1 segundo  
+**Reversible:** Sí
+
+```sql
+-- Opción 3: Volver a borrador_encoder para re-editar
+UPDATE grd_fila SET estado = 'borrador_encoder' WHERE id_grd_olivier = 68;
+```
+
+**Resultado:** Encoder puede volver a editar desde el principio
+
+---
+
+## 🎯 Recomendación
+
+**Para TESTING E2E de Rechazo:**
+
+### Plan Recomendado
+
+1. **Primero:** Exportar archivo actual (Opción 2)
+   ```sql
+   UPDATE grd_fila SET estado = 'exportado' WHERE id_grd_oficial = 68;
+   ```
+   - Cierra flujo correctamente sin perder datos
+   - Si algo sale mal, datos están disponibles
+
+2. **Luego:** Reimportar archivo SIGESA nuevo
+   - Usar la función de upload en `/upload`
+   - Comenzar testing desde cero con archivo fresco
+
+3. **O simplemente:** Borrar el archivo viejo (Opción 1)
+   ```sql
+   DELETE FROM grd_fila WHERE id_grd_oficial = 68;
+   ```
+   - Limpia completamente
+   - Testing comienza desde archivo nuevo
+
+---
+
+## ⚠️ Consideraciones Importantes
+
+### Antes de Ejecutar la Limpieza
+
+- [ ] ¿Hay datos en producción que necesites preservar?
+- [ ] ¿Este es ambiente de testing o producción?
+- [ ] ¿Tus usuarios necesitan datos históricos?
+
+### Impacto en Usuarios
+
+- **Encoder:** Perderá acceso a archivos en borrador_encoder
+- **Finance:** Perderá acceso a archivos en pendiente_finance
+- **Admin:** Perderá acceso a archivos en pendiente_admin
+
+---
+
+## 🔄 Paso a Paso - Opción Recomendada
+
+### PASO 1: Exportar Archivo (Cierre Normal)
+
+```sql
+-- Cambiar estado a exportado
+UPDATE grd_fila SET estado = 'exportado' WHERE id_grd_oficial = 68;
+
+-- Verificar que cambió
+SELECT estado, COUNT(*) FROM grd_fila WHERE id_grd_oficial = 68 GROUP BY estado;
+```
+
+**Resultado esperado:** 544 filas con estado `exportado`
+
+---
+
+### PASO 2: Verificar Limpieza
+
+```sql
+-- Verificar que no hay archivos en flujo activo
+SELECT estado, COUNT(*) FROM grd_fila 
+WHERE estado IN ('borrador_encoder', 'pendiente_finance', 'borrador_finance', 'pendiente_admin', 'rechazado')
+GROUP BY estado;
+```
+
+**Resultado esperado:** 0 resultados (vacío)
+
+---
+
+### PASO 3: Reimportar Archivo SIGESA (Opcional)
+
+Si quieres volver a probar desde cero:
+
+1. En la aplicación, ir a `/upload`
+2. Login como Encoder
+3. Seleccionar nuevo archivo SIGESA
+4. Cargarlo
+5. Comenzar testing
+
+---
+
+## ✅ Checklist de Limpieza
+
+- [ ] Verificar ambiente (¿testing o producción?)
+- [ ] Hacer backup de datos (si es crítico)
+- [ ] Ejecutar opción de limpieza elegida
+- [ ] Verificar que se ejecutó correctamente
+- [ ] Confirmar que sistema está limpio
+
+---
+
+## 🔍 Verificación Post-Limpieza
+
+Después de ejecutar la limpieza, verificar:
+
+```sql
+-- 1. Ver estado de archivos en flujo
+SELECT estado, COUNT(*) as total FROM grd_fila 
+WHERE estado IN ('borrador_encoder', 'pendiente_finance', 'borrador_finance', 'pendiente_admin', 'rechazado')
+GROUP BY estado;
+
+-- 2. Si fue limpieza completa, verificar que GRD 68 no existe
+SELECT COUNT(*) as total_filas FROM grd_fila WHERE id_grd_oficial = 68;
+
+-- 3. Ver próximo archivo disponible para testing
+SELECT DISTINCT id_grd_oficial, MIN(id) FROM grd_fila 
+WHERE estado NOT IN ('borrador_encoder', 'pendiente_finance', 'borrador_finance', 'pendiente_admin', 'rechazado')
+GROUP BY id_grd_oficial LIMIT 5;
+```
+
+---
+
+## 📞 Soporte
+
+Si hay problemas durante la limpieza:
+
+1. **Error de conexión:** Verificar credenciales de Supabase
+2. **Permiso denegado:** Verificar que tienes acceso admin en Supabase
+3. **Datos no borrados:** Verificar que la consulta SQL fue correcta
+
+---
+
+## 🎯 Resultado Esperado
+
+**Ambiente Limpio para Testing:**
+- ✅ Sistema sin archivos en flujo activo
+- ✅ Encoder puede subir archivo nuevo
+- ✅ Finance/Admin sin notificaciones pendientes
+- ✅ Dashboard limpio
+- ✅ Listo para PASO 3 de Testing E2E
+
+---
+
+**¿Ejecutar limpieza?** Sí / No
+
+Si sí, elegir opción:
+- [ ] Opción 1: Borrar completamente
+- [ ] Opción 2: Cambiar a exportado (RECOMENDADO)
+- [ ] Opción 3: Volver a borrador_encoder

--- a/docs/RECHAZO-IMPLEMENTACION.md
+++ b/docs/RECHAZO-IMPLEMENTACION.md
@@ -1,0 +1,319 @@
+# Implementación de Funcionalidad de Rechazo - Admin → Encoder
+
+**Fecha:** 2 de Diciembre, 2025  
+**Objetivo:** Habilitar el flujo completo de rechazo: Admin rechaza archivo → Encoder recibe notificación → Encoder puede reeditarlo
+
+---
+
+## 📋 Estado de Implementación
+
+### ✅ PASO 1: Permitir edición de Encoder en estado `rechazado`
+
+**Estado:** COMPLETADO ✅
+
+**Ubicación:** `src/components/ExcelEditor.tsx` - Línea 171-203
+
+**Detalles:**
+- La función `isFieldEditable()` ya incluye lógica para permitir edición cuando:
+  - `userRole === 'encoder'`
+  - `workflowEstado === 'rechazado'` ← Estado permitido
+  - Campo está en `ENCODER_EDITABLE_FIELDS` (AT, AT_detalle, centro, documentacion, etc.)
+
+**Código:**
+```tsx
+const isFieldEditable = (field: string, userRole?: string, workflowEstado?: string): boolean => {
+  // ...
+  
+  // Encoder: solo puede editar 'at' y 'at_detalle' en estado 'borrador_encoder' o 'rechazado'
+  if (userRole === 'encoder') {
+    if (!['borrador_encoder', 'rechazado'].includes(workflowEstado)) {
+      return false;
+    }
+    return ENCODER_EDITABLE_FIELDS.includes(field);
+  }
+  
+  // ...
+};
+```
+
+**Campos editables por Encoder:**
+- `AT` (Ajustes Tecnológicos)
+- `AT_detalle` (Detalle de AT)
+- `centro` (Centro)
+- `documentacion` (Documentación)
+- `dias_demora_rescate_hospital`
+- `pago_demora_rescate`
+- `pago_outlier_superior`
+
+---
+
+### ✅ PASO 2: Notificación visual al Encoder en Dashboard
+
+**Estado:** COMPLETADO ✅
+
+**Ubicaciones:**
+1. `src/app/dashboard/page.tsx` - Convertido a componente dinámico
+2. `src/app/dashboard/page.module.css` - Agregada sección `.alertSection`
+
+**Detalles de Implementación:**
+
+#### 2.1 Dashboard page.tsx
+
+**Cambios:**
+- Convertido de componente estático a dinámico ('use client')
+- Agregado `useEffect()` para cargar datos al montar el componente
+- Obtiene rol del usuario desde BD (tabla `users`)
+- Verifica estado del archivo según el rol:
+  - **Encoder:** Busca archivos con estado `rechazado`
+  - **Finance:** Busca archivos con estado `pendiente_finance`
+  - **Admin:** Busca archivos con estado `pendiente_admin`
+
+**Flujo de Notificación para Encoder:**
+
+```tsx
+if (userData.role === 'encoder') {
+  const { data: grdData } = await supabase
+    .from('grd_fila')
+    .select('id_grd_oficial, documentacion')
+    .eq('estado', 'rechazado')
+    .limit(1);
+
+  if (grdData && grdData.length > 0) {
+    setWorkflowAlert({
+      type: 'error',  // Alerta roja
+      message: `⚠️ Tu archivo fue rechazado. Razón: ${grdData[0].documentacion || 'Contacta al administrador'}`,
+      grdId: grdData[0].id_grd_oficial,
+    });
+  }
+}
+```
+
+**Notificación mostrada:**
+- Tipo: `error` (color rojo)
+- Mensaje: `⚠️ Tu archivo fue rechazado. Razón: [razón del rechazo]`
+- Botón: "Ver archivo" → Navega a `/visualizator`
+- Opción: Cerrar/Descartar la notificación
+
+#### 2.2 Estilos CSS
+
+**Agregado:** Nueva sección `.alertSection` con:
+- Margin bottom de 2rem
+- Animación de deslizamiento suave (`slideDown`)
+- Transición de 0.3s
+
+```css
+.alertSection {
+  margin-bottom: 2rem;
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+---
+
+### ✅ PASO 1.5: Visualización en Visualizator
+
+**Estado:** COMPLETADO ✅
+
+**Ubicación:** `src/app/visualizator/page.tsx` - Línea 164-181
+
+**Detalles:**
+- Cuando el usuario accede a `/visualizator` con estado `rechazado`:
+- Muestra alerta roja con ícono ⚠️
+- Mensaje: "Archivo Rechazado por el Administrador"
+- Indicación: "Este archivo fue rechazado. Por favor revisa los comentarios del administrador, realiza las correcciones necesarias y vuelve a enviarlo."
+
+**Código:**
+```tsx
+{/* Alerta si el archivo fue rechazado */}
+{estado === 'rechazado' && (
+  <div className="mb-4 bg-red-50 border-l-4 border-red-600 rounded-lg shadow p-4">
+    <div className="flex items-start">
+      <div className="flex-shrink-0">
+        <span className="text-2xl">⚠️</span>
+      </div>
+      <div className="ml-3 flex-1">
+        <h3 className="text-sm font-medium text-red-800">
+          Archivo Rechazado por el Administrador
+        </h3>
+        <div className="mt-2 text-sm text-red-700">
+          <p>Este archivo fue rechazado. Por favor revisa los comentarios del administrador, realiza las correcciones necesarias y vuelve a enviarlo.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+---
+
+## 🔄 Flujo Completo de Rechazo
+
+```
+1. ADMIN EN /visualizator
+   ├─ Estado: pendiente_admin
+   ├─ Botón visible: "❌ Rechazar Archivo"
+   ├─ Click → Abre RejectModal
+   │  └─ RejectModal solicita razón (min 10 caracteres)
+   │  └─ Confirma → POST /api/v1/grd/[grdId]/review
+   │     └─ Action: "reject"
+   │     └─ Reason: razón ingresada
+   │
+   └─ API actualiza: pendiente_admin → rechazado + guarda razón
+
+2. ENCODER EN /dashboard (siguiente acceso)
+   ├─ Dashboard detecta estado: rechazado
+   ├─ Carga notificación WorkflowAlert
+   │  ├─ Type: error (rojo)
+   │  ├─ Mensaje: "⚠️ Tu archivo fue rechazado. Razón: [razón]"
+   │  └─ Botón: "Ver archivo"
+   │
+   └─ Click "Ver archivo" → Navega a /visualizator
+
+3. ENCODER EN /visualizator
+   ├─ Obtiene archivo con estado: rechazado
+   ├─ Muestra alerta roja: "⚠️ Archivo Rechazado por el Administrador"
+   ├─ isFieldEditable() = true para campos Encoder
+   ├─ Puede editar: AT, AT_detalle, centro, documentacion, etc.
+   └─ Puede hacer Submit nuevamente
+
+4. ENCODER HACE SUBMIT
+   └─ Estado: rechazado → pendiente_finance (como de costumbre)
+
+5. FINANCE EN /dashboard
+   ├─ Recibe notificación: "pendiente_finance"
+   ├─ Continúa flujo normal
+   └─ Completa sus campos
+
+6. ADMIN EN /dashboard
+   ├─ Recibe notificación: "pendiente_admin"
+   ├─ Puede aprobar o rechazar nuevamente
+```
+
+---
+
+## 🚀 Pasos Siguientes
+
+### PASO 3: Testing Manual E2E
+
+**Objetivo:** Validar que todo el flujo funciona correctamente
+
+**Casos de Prueba:**
+
+1. **Case 1: Admin rechaza archivo**
+   - [ ] Encoder sube archivo SIGESA
+   - [ ] Finance edita y hace Submit
+   - [ ] Admin ve archivo en pendiente_admin
+   - [ ] Admin click "Rechazar" → Modal
+   - [ ] Admin ingresa razón
+   - [ ] Admin confirma
+   - [ ] API retorna 200 OK
+   - [ ] Estado cambia a rechazado
+
+2. **Case 2: Encoder recibe notificación**
+   - [ ] Encoder accede a dashboard
+   - [ ] Dashboard muestra WorkflowAlert roja
+   - [ ] Mensaje: "Tu archivo fue rechazado. Razón: [razón ingresada]"
+   - [ ] Botón "Ver archivo" funciona
+
+3. **Case 3: Encoder puede reeditarlo**
+   - [ ] Encoder click "Ver archivo"
+   - [ ] Visualizator muestra alerta roja
+   - [ ] Encoder puede editar campos AT, AT_detalle, centro, documentacion
+   - [ ] Cambios se guardan
+   - [ ] Encoder puede hacer Submit nuevamente
+
+4. **Case 4: Finance continúa flujo normal**
+   - [ ] Después del nuevo Submit del Encoder
+   - [ ] Finance recibe notificación
+   - [ ] Finance puede editar sus campos
+   - [ ] Finance hace Submit
+
+5. **Case 5: Admin aprueba segunda vez**
+   - [ ] Admin recibe notificación
+   - [ ] Admin puede aprobar (sin rechazar otra vez)
+   - [ ] Archivo pasa a estado aprobado
+   - [ ] Admin puede exportar
+
+---
+
+## 📋 Componentes Involucrados
+
+### APIs
+- `POST /api/v1/grd/[grdId]/review` - Aprobar/Rechazar archivo
+- `GET /api/v1/grd/active-workflow` - Obtener estado del flujo
+
+### Componentes
+- `ExcelEditor.tsx` - Incluye botones Aprobar/Rechazar
+- `RejectModal.tsx` - Modal para capturar razón del rechazo
+- `WorkflowAlert.tsx` - Banner de notificación en dashboard
+- `visualizator/page.tsx` - Alerta roja cuando estado = rechazado
+- `dashboard/page.tsx` - **NUEVO** - Notificación en dashboard
+
+### Base de Datos
+- Tabla `grd_fila` - Campo `estado` incluye valor `rechazado`
+- Campo `documentacion` - Almacena razón del rechazo
+
+---
+
+## 🔧 Configuración Requerida
+
+Ninguna configuración adicional necesaria. Todo está integrado.
+
+---
+
+## 📝 Notas Importantes
+
+1. **La razón del rechazo se guarda en `grd_fila.documentacion`**
+   - Consideración: Si Finance ya agregó un valor aquí, será sobrescrito
+   - Mejora futura: Crear campo dedicado `rechazo_razon`
+
+2. **El estado `rechazado` es temporal**
+   - Cuando Encoder hace Submit nuevamente, cambia a `pendiente_finance`
+   - No hay "historial" de rechazos (pero se puede auditar a nivel de BD con timestamps)
+
+3. **Encoder SOLO puede reedititar en estado `rechazado`**
+   - Una vez que hace Submit, pierde acceso nuevamente
+   - Finance y Admin pueden ver pero no editar cuando estado = rechazado
+
+4. **Todas las notificaciones son desechables**
+   - Usuario puede cerrar banner con botón X
+   - No persiste entre sesiones
+
+---
+
+## ✅ Checklist de Validación
+
+- [x] API de review implementada y funcional
+- [x] ExcelEditor tiene botones Aprobar/Rechazar
+- [x] RejectModal captura razón del rechazo
+- [x] Estado `rechazado` permitido en `isFieldEditable()`
+- [x] Visualizator muestra alerta roja para estado rechazado
+- [x] Dashboard muestra notificación al Encoder
+- [x] Transiciones de estado: pendiente_admin → rechazado → pendiente_finance
+- [x] No hay errores de compilación
+
+---
+
+## 🎯 Siguientes Sprints
+
+1. **Crear campo dedicado `rechazo_razon`** en `grd_fila`
+   - Evitar sobrescribir `documentacion` de Finance
+
+2. **Agregar historial de rechazos**
+   - Nueva tabla: `grd_rechazos` con timestamp, razón, usuario
+
+3. **Notificación por email** al Encoder cuando es rechazado
+
+4. **Métricas de rechazo**
+   - Dashboard admin con % de rechazos por usuario/mes

--- a/docs/TESTING-RECHAZO-E2E.md
+++ b/docs/TESTING-RECHAZO-E2E.md
@@ -1,0 +1,501 @@
+# Testing E2E - Funcionalidad de Rechazo Admin → Encoder
+
+**Fecha:** 2 de Diciembre, 2025  
+**Objetivo:** Validar el flujo completo de rechazo desde Admin hasta Encoder y vuelta a Finance
+
+---
+
+## 🎯 Flujo a Validar
+
+```
+Encoder subida → Finance edición → Admin rechazo → Encoder notificación → Encoder reedición → Finance continuación
+```
+
+---
+
+## 📋 Datos Necesarios
+
+### Usuarios de Prueba (verificar en BD)
+
+1. **Encoder:** `codificador@dataunion.cl` / `Admin123!`
+2. **Finance:** `finanzas@dataunion.cl` / `Admin123!`
+3. **Admin:** `admin@dataunion.cl` / `Admin123!`
+
+### Archivo de Prueba
+
+Usaremos un archivo Excel SIGESA con al menos 2-3 episodios para pruebas.
+
+---
+
+## ✅ CASE 1: Admin Rechaza Archivo
+
+### Prerequisitos
+- ✅ Archivo debe estar en estado `pendiente_admin`
+- ✅ Admin debe tener acceso a `/visualizator`
+
+### Pasos
+
+**1.1) Acceder como Admin**
+```
+1. Ir a https://dataunion.vercel.app/login
+2. Email: admin@dataunion.cl
+3. Password: Admin123!
+4. Click "Iniciar Sesión"
+```
+
+**Verificar:**
+- [ ] Admin logueado correctamente
+- [ ] Puede ver dashboard
+
+**1.2) Ir a Visualizator**
+```
+1. Click en "Editor" del sidebar O navegar a /visualizator
+2. El sistema debe cargar el archivo pendiente_admin automáticamente
+```
+
+**Verificar:**
+- [ ] Se carga archivo con múltiples filas (episodios)
+- [ ] Estado mostrado: `pendiente_admin`
+- [ ] Botones visibles: "✅ Aprobar Archivo" y "❌ Rechazar Archivo"
+
+**1.3) Click en "❌ Rechazar Archivo"**
+```
+1. Ubicar botón rojo "❌ Rechazar Archivo" (arriba a la derecha del grid)
+2. Click en botón
+```
+
+**Verificar:**
+- [ ] Modal "Rechazar Archivo" se abre
+- [ ] Modal muestra:
+  - Ícono de alerta ⚠️
+  - Título: "Rechazar Archivo"
+  - Subtitle: "Proporciona una razón clara para el rechazo"
+  - ID del archivo GRD
+
+**1.4) Ingresar Razón del Rechazo**
+```
+1. En textarea ingresarse un motivo claro, ej:
+   "Faltan datos en campos AT_detalle de episodios 2-5. Por favor completar con los ajustes tecnológicos específicos antes de reenviar."
+2. Verificar que se muestra contador de caracteres
+```
+
+**Verificar:**
+- [ ] Se puede escribir en textarea
+- [ ] Mínimo 10 caracteres validado
+- [ ] Botón "❌ Rechazar Archivo" se activa después de 10+ caracteres
+
+**1.5) Confirmar Rechazo**
+```
+1. Click en botón "❌ Rechazar Archivo"
+2. Sistema procesa...
+```
+
+**Verificar:**
+- [ ] Botón muestra loading: "⌛ Rechazando..."
+- [ ] Modal permanece abierto durante procesamiento
+- [ ] Después de 2-3 segundos:
+  - Alert: "✅ Archivo rechazado. El Encoder ha sido notificado."
+  - Modal se cierra
+  - Página se recarga
+
+**1.6) Verificar Resultado**
+```
+1. Después del reload, si intentas ver el archivo nuevamente:
+2. El estado debería ser ahora "rechazado"
+```
+
+**Verificar:**
+- [ ] Página recargó completamente
+- [ ] Botones de Admin (Aprobar/Rechazar) desaparecen
+- [ ] Se muestra nueva información del estado
+
+---
+
+## ✅ CASE 2: Encoder Recibe Notificación
+
+### Prerequisitos
+- ✅ Archivo fue rechazado en CASE 1
+- ✅ Estado en BD: `rechazado`
+
+### Pasos
+
+**2.1) Acceder como Encoder**
+```
+1. Cerrar sesión de Admin (logout)
+2. Ir a https://dataunion.vercel.app/login
+3. Email: codificador@dataunion.cl
+4. Password: Admin123!
+5. Click "Iniciar Sesión"
+```
+
+**Verificar:**
+- [ ] Encoder logueado correctamente
+- [ ] Se muestra dashboard
+
+**2.2) Verificar Notificación en Dashboard**
+```
+1. En la página /dashboard debe aparecer banner rojo
+```
+
+**Verificar:**
+- [ ] Banner rojo visible en el top (debajo de la navegación)
+- [ ] Icono: ⚠️
+- [ ] Mensaje dice: "Tu archivo fue rechazado"
+- [ ] Incluye la razón: "Faltan datos en campos AT_detalle..."
+- [ ] Botón visible: "Ver archivo"
+
+**2.3) Click en "Ver archivo"**
+```
+1. Click en botón "Ver archivo" del banner
+```
+
+**Verificar:**
+- [ ] Navega a `/visualizator`
+- [ ] El archivo se carga correctamente
+
+---
+
+## ✅ CASE 3: Encoder Puede Reeditarlo
+
+### Prerequisitos
+- ✅ Encoder en `/visualizator`
+- ✅ Estado archivo: `rechazado`
+
+### Pasos
+
+**3.1) Verificar Alerta Visual**
+```
+1. En la página /visualizator debe haber alerta roja
+```
+
+**Verificar:**
+- [ ] Alerta roja en top del contenido
+- [ ] Ícono: ⚠️
+- [ ] Título: "Archivo Rechazado por el Administrador"
+- [ ] Mensaje: "Este archivo fue rechazado. Por favor revisa..."
+
+**3.2) Intentar Editar Campo AT en una Fila**
+```
+1. Buscar columna "AT" en el grid
+2. Hacer doble-click en una celda AT en cualquier fila
+3. Intentar editar (ej: cambiar de vacío a "Sí")
+```
+
+**Verificar:**
+- [ ] La celda se vuelve editable (no está bloqueada)
+- [ ] Cursor aparece en la celda
+- [ ] Se puede escribir/cambiar el valor
+
+**3.3) Editar Campo AT_detalle**
+```
+1. Buscar columna "AT_detalle" en el grid
+2. Hacer doble-click en una celda AT_detalle
+3. Se debe abrir dropdown con opciones de AT vigentes
+```
+
+**Verificar:**
+- [ ] Campo editable (dropdown o textarea)
+- [ ] Se pueden seleccionar ajustes tecnológicos
+- [ ] El valor se actualiza
+
+**3.4) Guardar Cambios**
+```
+1. Press ENTER o click fuera de la celda para confirmar cambio
+2. Esperar confirmación visual
+```
+
+**Verificar:**
+- [ ] Cambio se guarda en la celda
+- [ ] No hay errores en la consola (F12 → Console)
+- [ ] La fila se marca como modificada (si hay indicador visual)
+
+**3.5) Editar Múltiples Filas**
+```
+1. Repetir pasos 3.2-3.4 para 2-3 filas más
+2. Cambiar valores de AT, AT_detalle, o documentación
+```
+
+**Verificar:**
+- [ ] Todas las ediciones se guardan correctamente
+- [ ] No hay conflictos entre cambios
+- [ ] El grid responde rápidamente
+
+---
+
+## ✅ CASE 4: Encoder Hace Submit Nuevamente
+
+### Prerequisitos
+- ✅ Encoder ha editado al menos 1 fila
+- ✅ Cambios guardados en BD
+
+### Pasos
+
+**4.1) Buscar Botón Submit**
+```
+1. Desplazarse a la derecha del grid (botones están en la esquina superior derecha)
+2. Buscar botón azul "Entregar a Finanzas"
+```
+
+**Verificar:**
+- [ ] Botón visible
+- [ ] Etiqueta: "Entregar a Finanzas"
+- [ ] Botón NO está deshabilitado
+
+**4.2) Click en "Entregar a Finanzas"**
+```
+1. Click en botón
+```
+
+**Verificar:**
+- [ ] Se abre Modal SubmitConfirmModal
+- [ ] Modal muestra confirmación doble
+- [ ] Mensaje: "¿Estás seguro de que deseas enviar este archivo a Finanzas?"
+
+**4.3) Confirmar Submit en Modal**
+```
+1. Verificar información en modal (GRD ID, número de filas, etc.)
+2. Click en "Sí, Enviar a Finanzas"
+```
+
+**Verificar:**
+- [ ] Botón de confirmación activo (no deshabilitado)
+- [ ] Modal muestra loading después del click
+
+**4.4) Esperar Resultado**
+```
+1. Sistema procesa (POST /api/v1/grd/[grdId]/submit-encoder)
+2. Debería tomar 2-5 segundos
+```
+
+**Verificar:**
+- [ ] Alert de éxito: "✅ Archivo entregado a Finanzas exitosamente"
+- [ ] Estado cambió: rechazado → pendiente_finance
+- [ ] Página se recarga
+- [ ] Botones desaparecen (Encoder pierde acceso)
+
+---
+
+## ✅ CASE 5: Finance Recibe y Continúa Flujo
+
+### Prerequisitos
+- ✅ Encoder hizo Submit
+- ✅ Archivo está en estado `pendiente_finance`
+
+### Pasos
+
+**5.1) Acceder como Finance**
+```
+1. Cerrar sesión de Encoder (logout)
+2. Ir a https://dataunion.vercel.app/login
+3. Email: finanzas@dataunion.cl
+4. Password: Admin123!
+5. Click "Iniciar Sesión"
+```
+
+**Verificar:**
+- [ ] Finance logueado correctamente
+- [ ] Se muestra dashboard
+
+**5.2) Verificar Notificación**
+```
+1. En dashboard debería haber banner
+```
+
+**Verificar:**
+- [ ] Banner amarillo/naranja visible
+- [ ] Mensaje: "Tienes un archivo pendiente de validación y completado de datos"
+- [ ] Botón: "Ver archivo"
+
+**5.3) Ir a Visualizator**
+```
+1. Click "Ver archivo" O navegar a /visualizator
+```
+
+**Verificar:**
+- [ ] Se carga archivo correctamente
+- [ ] Estado mostrado: `pendiente_finance`
+- [ ] Finance puede ver los cambios que hizo Encoder (AT actualizado)
+
+**5.4) Editar Campos de Finance**
+```
+1. Buscar campos editables para Finance: validado, n_folio, estado_rn, monto_rn
+2. Hacer doble-click en una celda (ej: n_folio)
+3. Ingresar un valor (ej: "2024-001234")
+```
+
+**Verificar:**
+- [ ] Campo editable
+- [ ] Se puede ingresar datos
+- [ ] Cambios se guardan
+
+**5.5) Finance Hace Submit a Admin**
+```
+1. Buscar botón azul "Entregar a Administración"
+2. Click en botón
+```
+
+**Verificar:**
+- [ ] Modal de confirmación aparece
+- [ ] Finance confirma
+- [ ] Alert de éxito
+- [ ] Estado cambió: pendiente_finance → borrador_finance → pendiente_admin
+
+---
+
+## ✅ CASE 6: Admin Aprueba (Segunda Revisión)
+
+### Prerequisitos
+- ✅ Finance hizo Submit
+- ✅ Archivo está en `pendiente_admin`
+
+### Pasos
+
+**6.1) Acceder como Admin**
+```
+1. Logout Finance
+2. Login como Admin
+```
+
+**Verificar:**
+- [ ] Admin logueado
+
+**6.2) Ver Archivo**
+```
+1. Dashboard mostrará notificación de archivo pendiente
+2. Click "Ver archivo" O ir a /visualizator
+```
+
+**Verificar:**
+- [ ] Se carga archivo
+- [ ] Estado: `pendiente_admin`
+- [ ] Botones Aprobar/Rechazar visibles
+
+**6.3) Revisar Cambios**
+```
+1. Revisar que los cambios del Encoder están presentes
+2. Revisar que los datos de Finance están completos
+```
+
+**Verificar:**
+- [ ] AT actualizado (del Encoder)
+- [ ] n_folio completado (de Finance)
+- [ ] Estado_rn, monto_rn completados (de Finance)
+
+**6.4) Aprobar Archivo**
+```
+1. Click en "✅ Aprobar Archivo"
+2. NO debe abrir modal (approval directo)
+```
+
+**Verificar:**
+- [ ] Alert: "✅ Archivo aprobado exitosamente. Ahora puedes descargarlo."
+- [ ] Página recarga
+- [ ] Botón "✅ Aprobado" aparece (deshabilitado)
+- [ ] Botón "📥 Descargar Excel" aparece
+
+**6.5) Descargar Excel**
+```
+1. Click en "📥 Descargar Excel"
+2. Se inicia descarga de archivo
+```
+
+**Verificar:**
+- [ ] Archivo se descarga (ver en carpeta de descargas del navegador)
+- [ ] Nombre del archivo algo como: `grd_export_[grdId]_[timestamp].xlsx`
+- [ ] Archivo tiene datos correctos (abrir en Excel y revisar)
+
+---
+
+## 📊 Matriz de Validación
+
+| Case | Paso | Acción | Verificación | ✓/✗ |
+|------|------|--------|--------------|-----|
+| 1 | 1.1 | Admin login | Logueado correctamente | [ ] |
+| 1 | 1.2 | Ir a /visualizator | Archivo carga en pending_admin | [ ] |
+| 1 | 1.3 | Botón rechazar | Modal abre | [ ] |
+| 1 | 1.4 | Ingresar razón | Min 10 caracteres validado | [ ] |
+| 1 | 1.5 | Confirmar | Alert y reload | [ ] |
+| 2 | 2.1 | Encoder login | Logueado correctamente | [ ] |
+| 2 | 2.2 | Ver dashboard | Banner rojo visible | [ ] |
+| 2 | 2.3 | Click ver archivo | Navega a /visualizator | [ ] |
+| 3 | 3.1 | Verificar alerta | Alerta roja visible en /visualizator | [ ] |
+| 3 | 3.2 | Editar AT | Campo editable, cambio guardado | [ ] |
+| 3 | 3.3 | Editar AT_detalle | Dropdown funciona | [ ] |
+| 3 | 3.4 | Guardar | Cambios persistidos | [ ] |
+| 4 | 4.1 | Buscar botón Submit | Botón visible | [ ] |
+| 4 | 4.2 | Click Submit | Modal abre | [ ] |
+| 4 | 4.3 | Confirmar | Modal procesa | [ ] |
+| 4 | 4.4 | Esperar resultado | Estado cambió a pending_finance | [ ] |
+| 5 | 5.1 | Finance login | Logueado correctamente | [ ] |
+| 5 | 5.2 | Dashboard | Banner visible | [ ] |
+| 5 | 5.3 | Ver archivo | Se carga correctamente | [ ] |
+| 5 | 5.4 | Editar campos Finance | Campos editables, cambios guardados | [ ] |
+| 5 | 5.5 | Submit Finance | Estado a pending_admin | [ ] |
+| 6 | 6.1 | Admin login | Logueado correctamente | [ ] |
+| 6 | 6.2 | Ver archivo | Se carga en pending_admin | [ ] |
+| 6 | 6.3 | Revisar cambios | Todos los cambios visibles | [ ] |
+| 6 | 6.4 | Aprobar | Estado aprobado, botón descargar visible | [ ] |
+| 6 | 6.5 | Descargar | Archivo se descarga correctamente | [ ] |
+
+---
+
+## 🐛 Bugs Encontrados (si aplica)
+
+Documentar aquí cualquier error o comportamiento inesperado:
+
+### Bug #1
+- **Description:** [Descripción del problema]
+- **Steps to Reproduce:** [Pasos para reproducir]
+- **Expected:** [Comportamiento esperado]
+- **Actual:** [Comportamiento real]
+- **Severity:** [Critical / High / Medium / Low]
+
+---
+
+## 📝 Notas de Testing
+
+### Ambiente
+- URL: https://dataunion.vercel.app
+- Branch: develop
+- Fecha de prueba: [Hoy]
+- Tester: [Tu nombre]
+
+### Observaciones Generales
+- [Agregar aquí observaciones generales]
+
+### Performance
+- Tiempo promedio de carga de /visualizator: [ ] segundos
+- Tiempo de Submit: [ ] segundos
+- Tiempo de rechazo: [ ] segundos
+
+---
+
+## ✅ Checklist Final
+
+- [ ] CASE 1 completado sin errores
+- [ ] CASE 2 completado sin errores
+- [ ] CASE 3 completado sin errores
+- [ ] CASE 4 completado sin errores
+- [ ] CASE 5 completado sin errores
+- [ ] CASE 6 completado sin errores
+- [ ] Todos los estados transicionan correctamente
+- [ ] Todas las notificaciones se muestran correctamente
+- [ ] No hay errores en la consola (F12 → Console)
+- [ ] Archivo final se descarga y abre correctamente
+
+---
+
+## 🎯 Resultado Final
+
+**TESTING E2E:** [ ] PASSED / [ ] FAILED
+
+**Resumen:**
+- Casos pasados: __/6
+- Casos fallidos: __/6
+- Issues críticas encontradas: __
+- Issues menores encontradas: __
+
+**Signature:**
+Tester: ________________  
+Date: ________________  
+Time: ________________

--- a/docs/TESTING-RECHAZO-QUICKSTART.md
+++ b/docs/TESTING-RECHAZO-QUICKSTART.md
@@ -1,0 +1,223 @@
+# Quick Start - Testing de Rechazo
+
+**Duración estimada:** 15-20 minutos  
+**Requisitos:** Navegador web, 3 cuentas de usuario (Encoder, Finance, Admin)
+
+---
+
+## 🚀 Inicio Rápido
+
+### Paso 1: Preparar Ambiente
+
+```bash
+# 1. Asegurar que estamos en rama develop
+git checkout develop
+
+# 2. Actualizar dependencias (si es necesario)
+npm install
+
+# 3. Iniciar servidor local (si no está corriendo)
+npm run dev
+```
+
+URL: http://localhost:3000 (local) o https://dataunion.vercel.app (producción)
+
+---
+
+### Paso 2: Preparar Datos (Estado Inicial)
+
+Necesitamos un archivo en estado `pendiente_admin` para empezar.
+
+**Opción A: Usar Archivo Existente**
+- Si ya hay un archivo en `pending_admin` en BD, saltar a Paso 3
+
+**Opción B: Crear Flujo Nuevo (5 min)**
+
+```sql
+-- En Supabase SQL Editor, ejecutar:
+
+-- 1. Crear GRD simulado (si no existe)
+INSERT INTO grd_fila (id_grd_oficial, episodio, estado, AT, AT_detalle)
+VALUES 
+  (999, 'EP001', 'pendiente_admin', false, NULL),
+  (999, 'EP002', 'pendiente_admin', false, NULL),
+  (999, 'EP003', 'pendiente_admin', true, 'Reintegro');
+
+-- 2. Verificar que se creó
+SELECT id, episodio, estado FROM grd_fila WHERE id_grd_oficial = 999;
+```
+
+---
+
+### Paso 3: Ejecutar Testing
+
+#### **CASE 1: Admin Rechaza (3 min)**
+
+```
+1. Login: admin@dataunion.cl / Admin123!
+2. Go to: https://dataunion.vercel.app/visualizator
+3. Find: "❌ Rechazar Archivo" button
+4. Click: Rechazar
+5. Modal: Ingresa razón > 10 caracteres
+6. Confirm: "❌ Rechazar Archivo"
+7. Verify: Alert "✅ Archivo rechazado"
+```
+
+**Resultado esperado:** Estado en BD cambió a `rechazado`
+
+---
+
+#### **CASE 2: Encoder Notificación (2 min)**
+
+```
+1. Logout: Admin
+2. Login: codificador@dataunion.cl / Admin123!
+3. Go to: https://dataunion.vercel.app/dashboard
+4. Verify: Banner rojo con razón del rechazo
+5. Click: "Ver archivo"
+6. Verify: Alerta en /visualizator
+```
+
+**Resultado esperado:** Encoder ve notificación con razón
+
+---
+
+#### **CASE 3: Encoder Reedit (4 min)**
+
+```
+1. En /visualizator como Encoder
+2. Doble-click en columna "AT" de una fila
+3. Cambiar a: "Sí" o "No"
+4. Doble-click en "AT_detalle"
+5. Seleccionar un AT del dropdown
+6. Press ENTER para guardar
+```
+
+**Resultado esperado:** Cambios se guardan sin error
+
+---
+
+#### **CASE 4: Encoder Submit (3 min)**
+
+```
+1. En /visualizator como Encoder
+2. Find: "Entregar a Finanzas" button (azul)
+3. Click: Entregar a Finanzas
+4. Modal: Click "Sí, Enviar a Finanzas"
+5. Verify: Alert "✅ Archivo entregado a Finanzas"
+```
+
+**Resultado esperado:** Estado cambió a `pendiente_finance`
+
+---
+
+#### **CASE 5: Finance Continúa (3 min)**
+
+```
+1. Logout: Encoder
+2. Login: finanzas@dataunion.cl / Admin123!
+3. Go to: https://dataunion.vercel.app/dashboard
+4. Verify: Banner con archivo pendiente
+5. Click: "Ver archivo"
+6. Doble-click en "n_folio"
+7. Ingresa: "2024-001"
+8. Press ENTER
+9. Click: "Entregar a Administración"
+10. Confirm: "Sí, Enviar a Administración"
+```
+
+**Resultado esperado:** Estado cambió a `pendiente_admin`
+
+---
+
+#### **CASE 6: Admin Aprueba (2 min)**
+
+```
+1. Logout: Finance
+2. Login: admin@dataunion.cl / Admin123!
+3. Go to: https://dataunion.vercel.app/visualizator
+4. Click: "✅ Aprobar Archivo"
+5. Verify: Alert "✅ Archivo aprobado"
+6. Verify: Botón "📥 Descargar Excel" aparece
+7. Click: Descargar Excel
+8. Verify: Archivo se descarga
+```
+
+**Resultado esperado:** Archivo descargado correctamente
+
+---
+
+## ✅ Checklist Rápido
+
+Marcar cada CASE conforme se completa:
+
+- [ ] CASE 1: Admin rechaza ✅
+- [ ] CASE 2: Encoder ve notificación ✅
+- [ ] CASE 3: Encoder puede reeditarlo ✅
+- [ ] CASE 4: Encoder reenvia ✅
+- [ ] CASE 5: Finance continúa ✅
+- [ ] CASE 6: Admin aprueba ✅
+
+---
+
+## 🔍 Debugging
+
+### Si hay error en CASE 1
+
+```
+1. Abrir DevTools (F12)
+2. Console: ¿Hay errores rojo?
+3. Network: Ver petición POST /api/v1/grd/[id]/review
+4. Response: ¿Status 200?
+```
+
+### Si hay error en CASE 2
+
+```
+1. Verificar en BD: SELECT * FROM grd_fila WHERE estado = 'rechazado'
+2. ¿Hay algún registro? Si no, CASE 1 falló
+3. Si sí, verificar en Network que dashboard hace GET a active-workflow
+```
+
+### Si hay error en CASE 3-4
+
+```
+1. Network: Ver PUT /api/v1/grd/rows/[episodio]
+2. Response: ¿Status 200? ¿Cambio se persistió en BD?
+3. Refrescar página y verificar que el cambio está
+```
+
+---
+
+## 📊 Resultado
+
+Si todos los CASE pasan: ✅ **TESTING EXITOSO**
+
+Si hay errores:
+1. Documentar el error en el formato TESTING-RECHAZO-E2E.md
+2. Crear issue en GitHub con: pasos, error, screenshot
+3. Asignar a developer correspondiente
+
+---
+
+## 💾 Cleanup (Opcional)
+
+Después de testing, limpiar datos:
+
+```sql
+-- Borrar datos de prueba
+DELETE FROM grd_fila WHERE id_grd_oficial = 999;
+```
+
+---
+
+## 📞 Soporte
+
+Si hay problemas:
+1. Verificar status de Supabase: https://status.supabase.com
+2. Revisar logs en Vercel: https://vercel.com/dashboard
+3. Contactar equipo: [contact info]
+
+---
+
+**¡Listo! Comenzar testing ahora →** https://dataunion.vercel.app/login

--- a/src/app/api/v1/grd/rows/[episodio]/route.schema.ts
+++ b/src/app/api/v1/grd/rows/[episodio]/route.schema.ts
@@ -6,7 +6,17 @@ import { episodioSchema } from '@/lib/api/validation'
  * All fields are optional except id and episodio which cannot be updated
  */
 export const updateGrdRowSchema = z.object({
-  validado: z.boolean().nullable().optional(),
+  validado: z
+    .union([
+      z.boolean(),
+      z.string().transform((val) => {
+        if (val === 'true' || val === 'Si' || val === 'Sí' || val === 'YES' || val === '1') return true
+        if (val === 'false' || val === 'No' || val === 'NO' || val === '0') return false
+        return null
+      })
+    ])
+    .nullable()
+    .optional(),
   centro: z.string().nullable().optional(),
   n_folio: z.string().nullable().optional(),
   rut_paciente: z.string().nullable().optional(),
@@ -16,7 +26,17 @@ export const updateGrdRowSchema = z.object({
   fecha_alta: z.string().nullable().optional(),
   servicios_alta: z.string().nullable().optional(),
   estado_rn: z.string().nullable().optional(),
-  AT: z.boolean().nullable().optional(),
+  AT: z
+    .union([
+      z.boolean(),
+      z.string().transform((val) => {
+        if (val === 'true' || val === 'Si' || val === 'Sí' || val === 'YES' || val === '1') return true
+        if (val === 'false' || val === 'No' || val === 'NO' || val === '0') return false
+        return null
+      })
+    ])
+    .nullable()
+    .optional(),
   AT_detalle: z.string().nullable().optional(),
   monto_AT: z.number().nullable().optional(),
   tipo_alta: z.string().nullable().optional(),
@@ -28,7 +48,17 @@ export const updateGrdRowSchema = z.object({
   pago_outlier_superior: z.number().nullable().optional(),
   documentacion: z.string().nullable().optional(),
   'inlier/outlier': z.string().nullable().optional(),
-  grupo_dentro_norma: z.boolean().nullable().optional(),
+  grupo_dentro_norma: z
+    .union([
+      z.boolean(),
+      z.string().transform((val) => {
+        if (val === 'true' || val === 'Si' || val === 'Sí' || val === 'YES' || val === '1') return true
+        if (val === 'false' || val === 'No' || val === 'NO' || val === '0') return false
+        return null
+      })
+    ])
+    .nullable()
+    .optional(),
   dias_estadia: z.number().nullable().optional(),
   precio_base_tramo: z.number().nullable().optional(),
   valor_GRD: z.number().nullable().optional(),

--- a/src/app/api/v1/grd/rows/[episodio]/route.ts
+++ b/src/app/api/v1/grd/rows/[episodio]/route.ts
@@ -58,10 +58,10 @@ export async function PUT(
     const { estado } = existingRow
     const { role } = user
 
-    // Encoder can only edit in borrador_encoder
-    if (role === 'encoder' && estado !== 'borrador_encoder') {
+    // Encoder can edit in borrador_encoder or rechazado (to fix rejections)
+    if (role === 'encoder' && !['borrador_encoder', 'rechazado'].includes(estado)) {
       return errorResponse(
-        `No puedes editar en estado: ${estado}. Solo puedes editar en 'borrador_encoder'.`,
+        `No puedes editar en estado: ${estado}. Solo puedes editar en 'borrador_encoder' o cuando el archivo es 'rechazado'.`,
         403
       )
     }
@@ -86,6 +86,11 @@ export async function PUT(
     let updatedEstado = estado
     if (role === 'finance' && estado === 'pendiente_finance') {
       updatedEstado = 'borrador_finance'
+    }
+    
+    // If Encoder is fixing a rejection (rechazado), change to borrador_encoder
+    if (role === 'encoder' && estado === 'rechazado') {
+      updatedEstado = 'borrador_encoder'
     }
 
     // Update the row with the new estado if needed

--- a/src/app/dashboard/page.module.css
+++ b/src/app/dashboard/page.module.css
@@ -7,6 +7,23 @@
   min-height: calc(100vh - 80px);
 }
 
+/* ---- SECCIÓN DE ALERTAS ---- */
+.alertSection {
+  margin-bottom: 2rem;
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* ---- HERO ---- */
 .hero {
   text-align: center;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,8 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import WorkflowAlert from '@/components/WorkflowAlert';
+import { createClient } from '@/lib/supabase/client';
 import styles from './page.module.css';
 
 export default function Home() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [role, setRole] = useState<string | null>(null);
+  const [workflowAlert, setWorkflowAlert] = useState<{
+    type: 'info' | 'warning' | 'error';
+    message: string;
+    grdId: number;
+  } | null>(null);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const supabase = createClient();
+
+        // 1. Obtener sesión
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+        
+        if (sessionError || !session) {
+          router.push('/login');
+          return;
+        }
+
+        // 2. Obtener rol del usuario
+        const { data: userData, error: userError } = await supabase
+          .from('users')
+          .select('role')
+          .eq('auth_id', session.user.id)
+          .single();
+
+        if (userError || !userData) {
+          setLoading(false);
+          return;
+        }
+
+        setRole(userData.role);
+
+        // 3. Obtener estado del flujo según el rol
+        if (userData.role === 'encoder') {
+          // Encoder: verificar si hay archivo rechazado
+          const { data: grdData } = await supabase
+            .from('grd_fila')
+            .select('id_grd_oficial, documentacion')
+            .eq('estado', 'rechazado')
+            .limit(1);
+
+          if (grdData && grdData.length > 0) {
+            setWorkflowAlert({
+              type: 'error',
+              message: `⚠️ Tu archivo fue rechazado. Razón: ${grdData[0].documentacion || 'Contacta al administrador'}`,
+              grdId: grdData[0].id_grd_oficial,
+            });
+          }
+        } else if (userData.role === 'finance') {
+          // Finance: verificar si hay archivo pendiente
+          const { data: grdData } = await supabase
+            .from('grd_fila')
+            .select('id_grd_oficial')
+            .eq('estado', 'pendiente_finance')
+            .limit(1);
+
+          if (grdData && grdData.length > 0) {
+            setWorkflowAlert({
+              type: 'warning',
+              message: '🔔 Tienes un archivo pendiente de validación y completado de datos',
+              grdId: grdData[0].id_grd_oficial,
+            });
+          }
+        } else if (userData.role === 'admin') {
+          // Admin: verificar si hay archivo pendiente de aprobación
+          const { data: grdData } = await supabase
+            .from('grd_fila')
+            .select('id_grd_oficial')
+            .eq('estado', 'pendiente_admin')
+            .limit(1);
+
+          if (grdData && grdData.length > 0) {
+            setWorkflowAlert({
+              type: 'warning',
+              message: '🔔 Tienes un archivo pendiente de aprobación',
+              grdId: grdData[0].id_grd_oficial,
+            });
+          }
+        }
+
+      } catch (error) {
+        console.error('Error loading dashboard:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadData();
+  }, [router]);
+
+  if (loading) {
+    return <div className={styles.container}>Cargando...</div>;
+  }
+
   return (
     <div className={styles.container}>
+
+      {/* Workflow Alert */}
+      {workflowAlert && (
+        <section className={styles.alertSection}>
+          <WorkflowAlert 
+            message={workflowAlert.message}
+            type={workflowAlert.type}
+            action={{
+              label: 'Ver archivo',
+              onClick: () => router.push('/visualizator')
+            }}
+            dismissible={true}
+            onDismiss={() => setWorkflowAlert(null)}
+          />
+        </section>
+      )}
 
       {/* Hero Section */}
       <section className={styles.hero}>


### PR DESCRIPTION
This pull request implements the full rejection workflow for document files, allowing Admins to reject files, notifying Encoders, and enabling Encoders to correct and resubmit files. It also adds documentation for database cleanup and quickstart testing of the rejection flow, and improves boolean field handling in API validation. The most important changes are grouped below:

### Rejection Workflow Implementation

* Encoders can now edit files not only in `borrador_encoder` state but also in `rechazado` state, enabling corrections after rejection. The API updates the file state to `borrador_encoder` when an Encoder edits a rejected file. ([src/app/api/v1/grd/rows/[episodio]/route.tsL61-R64](diffhunk://#diff-05e8847276961d4fb3a8f9f3c79491cb4a60d193093fca69b198e92076769888L61-R64), [src/app/api/v1/grd/rows/[episodio]/route.tsR91-R95](diffhunk://#diff-05e8847276961d4fb3a8f9f3c79491cb4a60d193093fca69b198e92076769888R91-R95))
* The dashboard now displays a visual alert for Encoders when a file is rejected, including the rejection reason and a link to view the file. Custom CSS provides a red alert banner with animation.
* Documentation added detailing the rejection workflow, involved components, API endpoints, and validation checklist for the feature.

### API and Validation Improvements

* Boolean fields (`validado`, `AT`, `grupo_dentro_norma`) in `updateGrdRowSchema` now accept both boolean and string values (e.g., "Sí", "No", "true", "false") and transform them appropriately, improving robustness of data handling. ([src/app/api/v1/grd/rows/[episodio]/route.schema.tsL9-R19](diffhunk://#diff-2423bc249c5afa7bb520fef44c3edd1cebc4e704a3c23c5639c432e895232c1dL9-R19), [src/app/api/v1/grd/rows/[episodio]/route.schema.tsL19-R39](diffhunk://#diff-2423bc249c5afa7bb520fef44c3edd1cebc4e704a3c23c5639c432e895232c1dL19-R39), [src/app/api/v1/grd/rows/[episodio]/route.schema.tsL31-R61](diffhunk://#diff-2423bc249c5afa7bb520fef44c3edd1cebc4e704a3c23c5639c432e895232c1dL31-R61))

### Testing and Database Cleanup Documentation

* Added a quickstart guide for manual E2E testing of the rejection workflow, including step-by-step instructions for all user roles and troubleshooting tips.
* Added a database cleanup plan document describing SQL options to reset the environment for fresh testing, with recommendations and verification steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables full rejection flow: encoders can edit rejected GRDs (auto-switching to borrador_encoder), dashboard shows role-based alerts, and API accepts boolean-like strings; adds cleanup and testing docs.
> 
> - **Backend/API**:
>   - Allow `encoder` edits when `estado` is `borrador_encoder` or `rechazado`; on edit in `rechazado`, auto-update to `borrador_encoder` (`src/app/api/v1/grd/rows/[episodio]/route.ts`).
>   - Preserve `finance` edit rules and transition `pendiente_finance` → `borrador_finance` (`src/app/api/v1/grd/rows/[episodio]/route.ts`).
>   - Expand boolean parsing in `updateGrdRowSchema` to accept booleans and localized strings for `validado`, `AT`, `grupo_dentro_norma` (`src/app/api/v1/grd/rows/[episodio]/route.schema.ts`).
> - **Frontend**:
>   - Convert `src/app/dashboard/page.tsx` to a client component; fetch session/role via Supabase and show role-based `WorkflowAlert` (e.g., rejected notice for encoders) with link to `/visualizator`.
>   - Add `.alertSection` styles and `slideDown` animation in `src/app/dashboard/page.module.css`.
> - **Docs**:
>   - Add `docs/RECHAZO-IMPLEMENTACION.md` detailing the rejection flow and components.
>   - Add `docs/TESTING-RECHAZO-E2E.md` and `docs/TESTING-RECHAZO-QUICKSTART.md` for manual testing.
>   - Add `docs/LIMPIEZA-BD.md` with SQL options for data cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50602391f95d4b67e02e8b309ac2f5d919d60d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->