### PR TITLE
feat: friendly error and AT filter for admin

### DIFF
--- a/planning/PLANNING.md
+++ b/planning/PLANNING.md
@@ -1,8 +1,8 @@
 # PLANNING.md - Sistema de Gestión de Codificación y Facturación Hospitalaria UC Christus
 
-**Última actualización:** 5 de Noviembre, 2025 (Tarde)  
-**Versión:** 1.5  
-**Estado del proyecto:** Sprint 3-4 completado (HU-03: Workflow ✅ + Admin UX: FASE 1+2 ✅)
+**Última actualización:** 2 de Diciembre, 2025  
+**Versión:** 1.6  
+**Estado del proyecto:** PASO 3 E2E Testing Completado ✅ (Flujo rechazo → corrección → aprobación funcional)
 
 ---
 
@@ -72,7 +72,7 @@ Plataforma web que automatice:
 - ✅ Mensajes descriptivos con episodios afectados
 - ✅ Validación mejorada para revisar todas las filas
 
-**TECH-007: FASE 1 - Admin UX Fix**
+**TECH-007: FASE 1 - Admin UX Fix** ✅
 
 - ✅ Eliminada redirección después de aprobar/rechazar
 - ✅ Admin se queda en página con archivo aprobado
@@ -80,7 +80,7 @@ Plataforma web que automatice:
 - ✅ Botón "Aprobado" bloqueado como indicador visual
 - ✅ Mejora de UX: de 6 pasos a 2 pasos para descargar
 
-**TECH-008: FASE 2 - Lista de Archivos Aprobados**
+**TECH-008: FASE 2 - Lista de Archivos Aprobados** ✅
 
 - ✅ Nueva página `/dashboard/archivos` para Admin
 - ✅ API GET `/api/v1/admin/approved-files`
@@ -88,6 +88,11 @@ Plataforma web que automatice:
 - ✅ Solo archivos aprobados (filtrado simplificado)
 - ✅ Botón "Descargar" directo (sin botón "Ver")
 - ✅ Ítem "Archivos" agregado al Sidebar (solo admin)
+
+**Bugs Solucionados (Diciembre 2025)**
+
+- ✅ **Validado field:** Schema Zod actualizado para aceptar boolean O string con transform
+- ✅ **Encoder editing en rechazado:** Flujo de workflow corregido en `/api/v1/grd/rows/[episodio]/route.ts`
 
 **Bugs Corregidos:**
 

--- a/planning/TASK.md
+++ b/planning/TASK.md
@@ -1,8 +1,8 @@
 # TASK.md - Backlog de Tareas del Proyecto
 
-**Última actualización:** 5 de Noviembre, 2025 (Tarde)  
-**Sprint Actual:** Sprint 3-4 (HU-03 + Admin UX Improvements - COMPLETADOS ✅)  
-**Estado del Proyecto:** En desarrollo activo - Workflow completo + Admin UX mejorada (100% FASE 1+2)
+**Última actualización:** 2 de Diciembre, 2025  
+**Sprint Actual:** PASO 3 Completado ✅ - Listo para siguiente fase  
+**Estado del Proyecto:** Flujo rechazo → corrección → aprobación funcional 100% (PASO 3 E2E validado)
 
 ---
 
@@ -29,7 +29,7 @@
 - **Tareas Completadas:** 7 bloques (BLOQUES 1-7) ✅
 - **Tareas Pendientes:** 1 bloque (Testing Manual E2E)
 
-**Bloques Completados:**
+**Bloques Completados (100% FUNCIONALES):**
 
 - ✅ **BLOQUE 1:** Migración estado 'rechazado' - Base de datos
 - ✅ **BLOQUE 2:** API validar archivo único - Control de workflow
@@ -38,10 +38,11 @@
 - ✅ **BLOQUE 5:** Botón Submit Finance - Entregar a Admin
 - ✅ **BLOQUE 6:** Botones Admin (Aprobar/Rechazar) - Review workflow
 - ✅ **BLOQUE 7:** Integración completa con /visualizator - Estado rechazado
+- ✅ **BLOQUE 8:** Testing Manual E2E - Validación Completa
 
-**Bloque Pendiente:**
+**Bloque Completado:**
 
-- ⏳ **BLOQUE 8:** Testing Manual Completo - Validación E2E
+- ✅ **PASO 3 E2E:** Testing end-to-end del flujo rechazo → corrección → aprobación (VALIDADO 2/dic/2025)
 
 **Regla Crítica del Flujo:**
 ⚠️ Solo puede existir UN archivo en proceso a la vez. Estados activos: `borrador_encoder`, `pendiente_finance`, `borrador_finance`, `pendiente_admin`, `rechazado`. Estados que liberan el sistema: `exportado`.
@@ -521,32 +522,25 @@
 
 ---
 
-### **BLOQUE 8: Testing Manual E2E - ⏰ 2-3 horas** - ⏳ **PENDIENTE**
+### **BLOQUE 8: Testing Manual E2E - ⏰ 2-3 horas** - ✅ **COMPLETADO**
 
-- ⏳ **WORKFLOW-008**: Testing end-to-end completo
-  - **Fecha Inicio:** Por definir
-  - **Estado:** ⏳ NO INICIADO
-  - **Documento:** `TEST-FLUJO-E2E.md` (creado)
-  - **Descripción:** Ejecutar testing manual de ambos flujos
-  - **Flujos a testear:**
-      1. **FLUJO 1 (Happy Path):** Encoder → Finance → Admin → Approve → Export
-      2. **FLUJO 2 (Rechazo):** Admin Reject → Encoder Fix → Resubmit → Approve
-  - **Validaciones críticas:**
-    - ✅ Archivo único (no permite carga si hay uno en proceso)
+- ✅ **WORKFLOW-008**: Testing end-to-end completo
+  - **Fecha Completado:** 2 de Diciembre, 2025
+  - **Estado:** ✅ COMPLETADO
+  - **Documento:** `TEST-FLUJO-E2E.md` (referencia)
+  - **Descripción:** Testing manual validado de ambos flujos
+  - **Flujos testeados:**
+      1. ✅ **FLUJO 1 (Happy Path):** Encoder → Finance → Admin → Approve ✅
+      2. ✅ **FLUJO 2 (Rechazo):** Admin Reject → Encoder Fix → Resubmit → Approve ✅
+  - **Validaciones completadas:**
+    - ✅ Archivo único validado
     - ✅ Permisos de edición por rol y estado
     - ✅ Transiciones de estado correctas
     - ✅ Modales de confirmación funcionando
     - ✅ Alerta de rechazo visible para encoder
     - ✅ Botones visibles según rol y estado
     - ✅ Loading states y error handling
-  - **Prerequisitos:**
-    - Usuarios de testing: <admin@test.com>, <encoder@test.com>, <finance@test.com>
-    - Archivo Excel de prueba (10-50 filas)
-    - Base de datos limpia
-  - **Entregables:**
-    - Screenshots de cada paso
-    - Reporte de bugs encontrados
-    - Validación de criterios de aceptación
+  - **Resultado:** PASO 3 E2E validado completamente
 
 ---
 
@@ -568,7 +562,7 @@
 
 ### **TECH DEBT IDENTIFICADO:**
 
-- **TECH-006**: Re-habilitar validación de campo `validado` en submit-finance
+| BLOQUE 8 | Testing E2E | 2-3 horas | ✅ | 2/dic | - |` en submit-finance
   - Actualmente comentada (líneas 102-110)
   - Razón: Permitir testing sin bloqueos
   - Prioridad: Media

--- a/src/app/api/v1/grd/rows/[episodio]/route.schema.ts
+++ b/src/app/api/v1/grd/rows/[episodio]/route.schema.ts
@@ -18,7 +18,13 @@ export const updateGrdRowSchema = z.object({
     .nullable()
     .optional(),
   centro: z.string().nullable().optional(),
-  n_folio: z.string().nullable().optional(),
+  n_folio: z
+    .union([
+      z.string(),
+      z.number().transform(v => String(v))
+    ])
+    .nullable()
+    .optional(),
   rut_paciente: z.string().nullable().optional(),
   nombre_paciente: z.string().nullable().optional(),
   tipo_episodio: z.string().nullable().optional(),

--- a/src/app/visualizator/page.tsx
+++ b/src/app/visualizator/page.tsx
@@ -23,6 +23,7 @@ export default function VisualizatorPage() {
   const [role, setRole] = useState<'admin' | 'encoder' | 'finance' | null>(null);
   const [grdId, setGrdId] = useState<string | null>(null);
   const [estado, setEstado] = useState<'borrador_encoder' | 'pendiente_finance' | 'borrador_finance' | 'pendiente_admin' | 'aprobado' | 'exportado' | 'rechazado' | null>(null);
+  const [filterOnlyAT, setFilterOnlyAT] = useState(false);
 
   useEffect(() => {
     async function loadData() {
@@ -179,11 +180,32 @@ export default function VisualizatorPage() {
           </div>
         </div>
       )}
+
+      {/* Filtro de AT - Solo para Admin */}
+      {role === 'admin' && (
+        <div className="mb-4 bg-white rounded-lg shadow p-4">
+          <label className="flex items-center cursor-pointer">
+            <input
+              type="checkbox"
+              checked={filterOnlyAT}
+              onChange={(e) => setFilterOnlyAT(e.target.checked)}
+              className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+            />
+            <span className="ml-2 text-sm font-medium text-gray-700">
+              🔍 Solo episodios con Ajustes Tecnológicos (AT)
+            </span>
+          </label>
+          <p className="text-xs text-gray-500 mt-2 ml-6">
+            Este filtro es solo visual. No afecta la exportación del archivo.
+          </p>
+        </div>
+      )}
       
       <ExcelEditor 
         role={role}
         grdId={grdId}
         estado={estado}
+        filterOnlyAT={filterOnlyAT}
       />
     </div>
   );

--- a/src/components/ExcelEditor.tsx
+++ b/src/components/ExcelEditor.tsx
@@ -19,7 +19,8 @@ import type {
   AGCellClassParams,
   AGGetRowsParams,
   AGColDef,
-  AGGridRef
+  AGGridRef,
+  AGCellValueChangedParams
 } from "@/types/ag-grid.types";
 
 // Constants
@@ -1309,7 +1310,7 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
               paginationPageSize={10}
               datasource={datasource}
               singleClickEdit={true}
-              onCellValueChanged={(event) => {
+              onCellValueChanged={(event: AGCellValueChangedParams<GrdRowData>) => {
                 // Refresh only the changed cell to show the new value immediately
                 if (event.node && event.column) {
                   event.api.refreshCells({

--- a/src/components/ExcelEditor.tsx
+++ b/src/components/ExcelEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect, useRef } from "react";
+import React, { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { ModuleRegistry, AllCommunityModule } from "ag-grid-community";
@@ -144,8 +144,7 @@ interface ValidationResult {
 }
 
 // Campos editables por Encoder
-const ENCODER_EDITABLE_FIELDS = ['AT', 'AT_detalle', 'centro', 'documentacion', 'dias_demora_rescate_hospital', 'pago_demora_rescate',
-  'pago_outlier_superior'];
+const ENCODER_EDITABLE_FIELDS = ['AT', 'AT_detalle', 'centro'];
 
 // Campos editables por Finance
 const FINANCE_EDITABLE_FIELDS = ['validado', 'n_folio', 'estado_rn', 'monto_rn'];
@@ -369,12 +368,14 @@ interface ExcelEditorProps {
   role?: UserRole;
   grdId?: string;
   estado?: WorkflowEstado;
+  filterOnlyAT?: boolean;
 }
 
-export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, estado = 'borrador_encoder' }: ExcelEditorProps) {
+export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, estado = 'borrador_encoder', filterOnlyAT = false }: ExcelEditorProps) {
   // Usar grdId de props o cargar el primero disponible (fallback temporal)
   const [grdId, setGrdId] = useState<string | null>(grdIdProp || null);
   const [rowData, setRowData] = useState<GrdRowData[]>([]);
+  const [displayRowData, setDisplayRowData] = useState<GrdRowData[]>([]);
 
   // Estados para workflow
   const [showSubmitModal, setShowSubmitModal] = useState(false);
@@ -429,12 +430,14 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
 
         try {
           const errorJson = JSON.parse(responseText);
+          // Mostrar solo el error del backend, que ya es amigable
           errorDetail = errorJson.message || errorJson.error || res.statusText;
         } catch {
-          errorDetail = responseText || `${res.status} ${res.statusText}`;
+          // Si no es JSON válido, mostrar mensaje genérico amigable
+          errorDetail = 'No se pudo procesar la solicitud. Por favor, intenta de nuevo.';
         }
 
-        throw new Error(`Error al guardar fila ${episodio}: ${errorDetail}`);
+        throw new Error(`Episodio ${episodio}: ${errorDetail}`);
       }
 
       await res.json();
@@ -459,17 +462,37 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
         )
       );
 
-      const errors = results
-        .map((r, i) => r.status === 'rejected' ? Object.keys(modifiedRows)[i] : null)
+      const errorDetails = results
+        .map((r, i) => {
+          if (r.status === 'rejected') {
+            const errorMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+            // Filtrar errores técnicos (de sistema), mostrar solo errores de negocio
+            if (errorMsg.includes('Cannot read') || errorMsg.includes('TypeError')) {
+              console.error('Technical error caught:', errorMsg);
+              return 'Hubo un problema al guardar. Por favor, intenta de nuevo.';
+            }
+            return errorMsg;
+          }
+          return null;
+        })
         .filter(Boolean);
 
-      if (errors.length > 0) {
-        setSaveError(`Error al guardar las filas: ${errors.join(', ')}`);
+      if (errorDetails.length > 0) {
+        // Deduplicar errores iguales
+        const uniqueErrors = [...new Set(errorDetails)];
+        setSaveError(`❌ ${uniqueErrors.join('\n\n')}`);
       } else {
         setModifiedRows({});
       }
-    } catch {
-      setSaveError('Error al guardar cambios');
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      // Filtrar errores técnicos
+      if (errorMsg.includes('Cannot read') || errorMsg.includes('TypeError')) {
+        console.error('Technical error caught:', errorMsg);
+        setSaveError('❌ Hubo un problema al guardar. Por favor, intenta de nuevo.');
+      } else {
+        setSaveError(`❌ ${errorMsg}`);
+      }
     } finally {
       setIsSaving(false);
     }
@@ -537,7 +560,24 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
 
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({}));
-        throw new Error(errorData.error || 'Error al entregar archivo');
+        
+        // Construir mensaje de error detallado
+        let errorMessage = errorData.error || 'Error al entregar archivo';
+        
+        if (errorData.details) {
+          const details = errorData.details;
+          if (details.message) {
+            errorMessage = details.message;
+          }
+          if (details.hint) {
+            errorMessage = `${errorMessage}\n\n${details.hint}`;
+          }
+          if (details.sampleEpisodios && Array.isArray(details.sampleEpisodios)) {
+            errorMessage = `${errorMessage}\n\nEpisodios afectados: ${details.sampleEpisodios.join(', ')}`;
+          }
+        }
+        
+        throw new Error(errorMessage);
       }
 
 
@@ -900,7 +940,7 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
         base.valueFormatter = (params: AGValueFormatterParams<GrdRowData>) => params.value as string;
       }
 
-      if (["AT", "validado", "documentacion"].includes(c.field)) {
+      if (["AT", "validado"].includes(c.field)) {
         base.cellEditor = "agSelectCellEditor";
         base.cellEditorParams = {
           values: [true, false],  // Only Sí and No, no blank option
@@ -921,6 +961,70 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
           if (params.value === false) return "No";
           if (params.value === null) return "";
           return "";
+        };
+
+        // Cell renderer para asegurar que siempre muestre el texto formateado
+        base.cellRenderer = (params: AGCellRendererParams<GrdRowData>) => {
+          if (params.value === true) return "Sí";
+          if (params.value === false) return "No";
+          return "";
+        };
+
+        // ValueSetter específico para campos booleanos (sobrescribe el genérico)
+        base.valueSetter = (params: AGValueSetterParams<GrdRowData>) => {
+          if (!fieldEditable) return false;
+          
+          let newVal = params.newValue;
+          
+          // Convertir cualquier formato a booleano
+          if (newVal === 'true' || newVal === true || newVal === 1 || newVal === '1') {
+            newVal = true;
+          } else if (newVal === 'false' || newVal === false || newVal === 0 || newVal === '0') {
+            newVal = false;
+          } else if (newVal === null || newVal === '') {
+            newVal = null;
+          } else {
+            // Si es string, intentar parsear
+            const raw = String(newVal).toLowerCase();
+            if (["sí", "si", "s", "yes"].includes(raw)) {
+              newVal = true;
+            } else if (["no", "n"].includes(raw)) {
+              newVal = false;
+            } else {
+              return false;
+            }
+          }
+          
+          if (params.data) {
+            const oldValue = params.data[c.field as keyof GrdRowData];
+            (params.data as Record<string, unknown>)[c.field] = newVal;
+            
+            const changed = oldValue !== newVal;
+            if (params.data.episodio && changed) {
+              setModifiedRows(prev => ({
+                ...prev,
+                [params.data!.episodio!]: {
+                  ...(prev[params.data!.episodio!] || {}),
+                  ...params.data
+                }
+              }));
+            }
+            
+            // Trigger immediate refresh to show the formatted value
+            if (params.node && params.column) {
+              setTimeout(() => {
+                params.api.refreshCells({
+                  rowNodes: [params.node!],
+                  columns: [params.column!.getColId()],
+                  force: true
+                });
+              }, 0);
+            }
+            
+            return true;
+          }
+          
+          return false;
         };
 
         // Para el campo AT, solo permitir edición si el convenio es FNS012 o CH0041
@@ -1070,7 +1174,19 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
     fetchGRDData();
   }, [validateRow]);
 
-  const datasource = {
+  // Aplicar filtro visual de AT cuando filterOnlyAT cambia
+  useEffect(() => {
+    if (filterOnlyAT && rowData.length > 0) {
+      // Filtrar solo filas donde AT === true
+      const filtered = rowData.filter(row => row.AT === true);
+      setDisplayRowData(filtered);
+    } else {
+      // Mostrar todas las filas
+      setDisplayRowData(rowData);
+    }
+  }, [filterOnlyAT, rowData]);
+
+  const datasource = useMemo(() => ({
     getRows: async (params: AGGetRowsParams) => {
       const page = Math.floor(params.startRow / params.endRow) + 1;
       const limit = params.endRow - params.startRow;
@@ -1080,12 +1196,17 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
           `/api/v1/grd/${grdId}/rows?page=${page}&pageSize=${limit}`
         );
         const json = await res.json();
-        const mergedData = (json.data || []).map((row: GrdRowData) => {
+        let mergedData = (json.data || []).map((row: GrdRowData) => {
           const modified = modifiedRows[row.episodio!];
           return modified ? { ...row, ...modified } : row;
         });
 
-        params.successCallback(mergedData, json.total);
+        // Aplicar filtro visual de AT si está activo
+        if (filterOnlyAT) {
+          mergedData = mergedData.filter((row: GrdRowData) => row.AT === true);
+        }
+
+        params.successCallback(mergedData, filterOnlyAT ? mergedData.length : json.total);
       } catch {
         params.failCallback();
       } finally {
@@ -1096,7 +1217,7 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
         }, 600);
       }
     },
-  };
+  }), [filterOnlyAT, grdId, modifiedRows]);
 
 
   const handleDownload = useCallback(async () => {
@@ -1167,9 +1288,12 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
           )}
 
           {saveError && (
-            <span className="text-red-600 flex items-center gap-1">
-              ❌ {saveError}
-            </span>
+            <div className="text-red-600 flex items-start gap-2 bg-red-50 border border-red-200 rounded p-3 text-sm">
+              <span className="flex-shrink-0 mt-0.5">❌</span>
+              <div className="flex-1 whitespace-pre-wrap break-words">
+                {saveError}
+              </div>
+            </div>
           )}
         </div>
       </div>
@@ -1185,9 +1309,14 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
               paginationPageSize={10}
               datasource={datasource}
               singleClickEdit={true}
-              onCellValueChanged={() => {
-                if (gridRef.current?.api) {
-                  gridRef.current.api.showLoadingOverlay();
+              onCellValueChanged={(event) => {
+                // Refresh only the changed cell to show the new value immediately
+                if (event.node && event.column) {
+                  event.api.refreshCells({
+                    rowNodes: [event.node],
+                    columns: [event.column.getColId()],
+                    force: true
+                  });
                 }
               }}
               localeText={{
@@ -1337,17 +1466,17 @@ export default function ExcelEditorAGGrid({ role = 'encoder', grdId: grdIdProp, 
             )}
           </div>
           {saveError && (
-            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300">
+            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300 whitespace-pre-wrap break-words text-sm">
               ❌ {saveError}
             </div>
           )}
           {submitError && (
-            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300">
+            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300 whitespace-pre-wrap break-words text-sm">
               ❌ {submitError}
             </div>
           )}
           {approveError && (
-            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300">
+            <div className="mt-4 p-4 bg-red-50 text-red-700 rounded border border-red-300 whitespace-pre-wrap break-words text-sm">
               ❌ {approveError}
             </div>
           )}

--- a/src/types/ag-grid.types.ts
+++ b/src/types/ag-grid.types.ts
@@ -17,12 +17,25 @@ export interface AGCellRendererParams<TData = unknown> {
   api: AGGridApi;
 }
 
+export interface AGColumn {
+  getColId: () => string;
+}
+
 export interface AGValueSetterParams<TData = unknown> {
   data?: TData;
   newValue: unknown;
   oldValue?: unknown;
   node?: unknown;
-  column?: unknown;
+  column?: AGColumn;
+  api: AGGridApi;
+}
+
+export interface AGCellValueChangedParams<TData = unknown> {
+  data?: TData;
+  newValue: unknown;
+  oldValue?: unknown;
+  node?: unknown;
+  column?: AGColumn;
   api: AGGridApi;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an admin-only AT filter in the visualizator and refines validation/boolean handling with clearer, user-friendly errors; updates docs to reflect E2E completion.
> 
> - **Frontend**:
>   - **Visualizator**: Admin-only checkbox filter `filterOnlyAT` to show only rows with `AT=true` in `src/app/visualizator/page.tsx`, passed to `ExcelEditor`.
>   - **ExcelEditor** (`src/components/ExcelEditor.tsx`):
>     - Friendlier error messages and aggregation for saves and submit-finance; improved display of multi-line errors.
>     - Boolean fields (`AT`, `validado`): consistent parsing/formatting, custom `valueSetter`/renderer, immediate cell refresh on change.
>     - Role/fields: narrows encoder editable fields; AT editing constrained by convenio; maintains read-only visuals with lock renderer.
>     - Data source: supports visual AT-only filtering (does not affect export/pagination totals when off).
>     - Minor UX: improved error banners; `onCellValueChanged` refresh.
> - **Backend/API**:
>   - `route.schema.ts`: `n_folio` now accepts `string | number` (number transformed to string); `validado` transform maintained.
>   - `route.ts`: returns detailed Zod validation issue messages instead of generic 400.
> - **Types**:
>   - `src/types/ag-grid.types.ts`: add `AGColumn`, `AGCellValueChangedParams`; enhance `AGValueSetterParams` to include `column` and `api`.
> - **Docs**:
>   - `planning/PLANNING.md`, `planning/TASK.md`: update status to 2025-12-02; mark E2E testing (PASO 3) completed; add recent bug fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58c4d6f7f4b4cc26e376d5be71aad1f018b97267. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->